### PR TITLE
Update macos-guest-virtualbox.sh

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -479,8 +479,7 @@ echo ""
 echo "When the installer finishes preparing, the virtual machine will reboot"
 echo "into the base system, not the installer."
 printf ${whiteonblack}'
-After the reboot, press enter when the Language window '
-'or Utilities window is ready.'${defaultcolor}
+After the reboot, press enter when the Language window or Utilities window is ready.'${defaultcolor}
 read -p ""
 sendenter
 


### PR DESCRIPTION
Should prevent `After the reboot, press enter when the Language window ./macos-guest-virtualbox.sh: line 483: or Utilities window is ready.\033[0m: command not found`